### PR TITLE
Rl patch release update

### DIFF
--- a/task-updating-ontap-cloud.adoc
+++ b/task-updating-ontap-cloud.adoc
@@ -108,7 +108,7 @@ Note the following:
 For example, if you're running version 9.8 and you want to upgrade to 9.10.1, you first need to upgrade to version 9.9.1 and then to 9.10.1.
 
 === Patch releases
-Starting in December 2023, patch upgrades are only available in BlueXP if they are a patch release for the three latest versions of Cloud Volumes ONTAP. We use the latest GA release to determine the three latest versions to display in BlueXP. For example, if the current GA release is 9.13.1, patches for 9.11.1-9.13.1 appear in BlueXP. If you want to upgrade to a patch release for versions 9.11.1 or below, you will need to use the manual upgrade procedure by <<Upgrade from an image available at a URL,downloading the ONTAP image>>.
+Starting in January 2024, patch upgrades are only available in BlueXP if they are a patch release for the three latest versions of Cloud Volumes ONTAP. We use the latest GA release to determine the three latest versions to display in BlueXP. For example, if the current GA release is 9.13.1, patches for 9.11.1-9.13.1 appear in BlueXP. If you want to upgrade to a patch release for versions 9.11.1 or below, you will need to use the manual upgrade procedure by <<Upgrade from an image available at a URL,downloading the ONTAP image>>.
 
 As a general rule for patch (P) releases, you can upgrade from one version release to any P-release of the current version you're running or the next version. 
 

--- a/task-updating-ontap-cloud.adoc
+++ b/task-updating-ontap-cloud.adoc
@@ -108,7 +108,7 @@ Note the following:
 For example, if you're running version 9.8 and you want to upgrade to 9.10.1, you first need to upgrade to version 9.9.1 and then to 9.10.1.
 
 === Patch releases
-Starting in December 2023, patch upgrades are only available in BlueXP if they are a patch release for the three latest versions of Cloud Volumes ONTAP. You can upgrade automatically in BlueXP to a patch release if you're running versions 9.12.1 up to 9.14.0. If you want to upgrade to a patch release for versions 9.11.1 or below, you will need to use the manual upgrade procedure by <<Upgrade from an image available at a URL,downloading the ONTAP image>>.
+Starting in December 2023, patch upgrades are only available in BlueXP if they are a patch release for the three latest versions of Cloud Volumes ONTAP. We use the latest GA release to determine the three latest versions to display in BlueXP. For example, if the current GA release is 9.13.1, patches for 9.11.1-9.13.1 appear in BlueXP. If you want to upgrade to a patch release for versions 9.11.1 or below, you will need to use the manual upgrade procedure by <<Upgrade from an image available at a URL,downloading the ONTAP image>>.
 
 As a general rule for patch (P) releases, you can upgrade from one version release to any P-release of the current version you're running or the next version. 
 

--- a/task-updating-ontap-cloud.adoc
+++ b/task-updating-ontap-cloud.adoc
@@ -104,7 +104,7 @@ Note the following:
 For example, if you're running version 9.8 and you want to upgrade to 9.10.1, you first need to upgrade to version 9.9.1 and then to 9.10.1.
 
 === Patch releases
-Starting with Cloud Volumes ONTAP 9.14.1, patch upgrades are only available in BlueXP if they are a patch release for the three latest versions. You can upgrade automatically in BlueXP to a patch release if you're running versions 9.12.1 up to 9.14.1. If you want to upgrade to a patch release for versions 9.11.1 or below, you will need to use the manual upgrade procedure by <<Upgrade from an image available at a URL,downloading the ONTAP image>>.
+Starting in December 2023, patch upgrades are only available in BlueXP if they are a patch release for the three latest versions of Cloud Volumes ONTAP. You can upgrade automatically in BlueXP to a patch release if you're running versions 9.12.1 up to 9.14.0. If you want to upgrade to a patch release for versions 9.11.1 or below, you will need to use the manual upgrade procedure by <<Upgrade from an image available at a URL,downloading the ONTAP image>>.
 
 As a general rule for patch (P) releases, you can upgrade from one version release to any P-release of the current version you're running or the next version. 
 

--- a/task-updating-ontap-cloud.adoc
+++ b/task-updating-ontap-cloud.adoc
@@ -104,7 +104,7 @@ Note the following:
 For example, if you're running version 9.8 and you want to upgrade to 9.10.1, you first need to upgrade to version 9.9.1 and then to 9.10.1.
 
 === Patch releases
-Starting with Cloud Volumes ONTAP 9.14.1, patch upgrades are only available in BlueXP if they are a patch release for the most recent version and back two versions. You can upgrade automatically in BlueXP to a patch release if you're running versions 9.12.1 up to 9.14.1. If you want to upgrade to a patch release for versions 9.11.1 or below, you will need to use the manual upgrade procedure by <<Upgrade from an image available at a URL,downloading the ONTAP image>>.
+Starting with Cloud Volumes ONTAP 9.14.1, patch upgrades are only available in BlueXP if they are a patch release for the three latest versions. You can upgrade automatically in BlueXP to a patch release if you're running versions 9.12.1 up to 9.14.1. If you want to upgrade to a patch release for versions 9.11.1 or below, you will need to use the manual upgrade procedure by <<Upgrade from an image available at a URL,downloading the ONTAP image>>.
 
 As a general rule for patch (P) releases, you can upgrade from one version release to any P-release of the current version you're running or the next version. 
 

--- a/task-updating-ontap-cloud.adoc
+++ b/task-updating-ontap-cloud.adoc
@@ -103,13 +103,15 @@ Note the following:
 +
 For example, if you're running version 9.8 and you want to upgrade to 9.10.1, you first need to upgrade to version 9.9.1 and then to 9.10.1.
 
-* For patch (P) releases, you can upgrade from one version release to any P-release of the next version. 
-+
+=== Patch releases
+Starting with Cloud Volumes ONTAP 9.14.1, patch upgrades are only available in BlueXP if they are a patch release for the most recent version and back two versions. You can upgrade automatically in BlueXP to a patch release if you're running versions 9.12.1 up to 9.14.1. If you want to upgrade to a patch release for versions 9.11.1 or below, you will need to use the manual upgrade procedure by <<Upgrade from an image available at a URL,downloading the ONTAP image>>.
+
+As a general rule for patch (P) releases, you can upgrade from one version release to any P-release of the current version you're running or the next version. 
+
 Here are a couple examples:
 
-**	9.13.0 > 9.13.1P15
-**	9.12.1 > 9.13.1P2
-
+*	9.13.0 > 9.13.1P15
+*	9.12.1 > 9.13.1P2
 
 === Reverting or downgrading
 

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -20,6 +20,13 @@ The enhancements described on this page are specific to BlueXP features that ena
 //The whats-new tag should be enclosed around the three most recent releases. Be sure to use absolute URLs for links and images. Begin images like this: image:https://raw.githubusercontent.com/NetAppDocs/bluexp-cloud-volumes-ontap/main/media/[file-name].png. This is required so that the what's new content can be reused in the bluexp-relnotes doc site. To begin the tag, use //tag::whats-new[]. To end the tag, use //end::whats-new[].
 
 //tag::whats-new[]
+== 16 January 2024
+
+=== Patch releases in BlueXP
+Patch releases are available in BlueXP only for the latest three versions of Cloud Volumes ONTAP. 
+
+link:https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-updating-ontap-cloud.html#patch-releases[Patch releases]
+
 == 8 January 2024
 
 === New VMs for Azure multiple availability zones
@@ -36,6 +43,7 @@ link:https://docs.netapp.com/us-en/cloud-volumes-ontap-relnotes/reference-config
 
 === Cloud Volumes ONTAP 9.14.1 RC1
 BlueXP can now deploy and manage Cloud Volumes ONTAP 9.14.1 in AWS, Azure, and Google Cloud.
+//end::whats-new[]
 
 == 5 December 2023
 The following changes were introduced. 
@@ -59,7 +67,6 @@ The following regions now support highly-available multiple availability zone de
 * China North 3
 
 For a list of all regions, see the https://bluexp.netapp.com/cloud-volumes-global-regions[Global Regions Map under Azure^]. 
-//end::whats-new[]
 
 == 10 November 2023
 The following change was introduced with the 3.9.35 release of the Connector.

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -25,7 +25,7 @@ The enhancements described on this page are specific to BlueXP features that ena
 === Patch releases in BlueXP
 Patch releases are available in BlueXP only for the latest three versions of Cloud Volumes ONTAP. 
 
-link:https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-updating-ontap-cloud.html#patch-releases[Patch releases]
+link:https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-updating-ontap-cloud.html#patch-releases[Upgrade Cloud Volumes ONTAP^]
 
 == 8 January 2024
 


### PR DESCRIPTION
Patch releases in BlueXP are now only available for the three latest versions. I added a new section in Upgrade Cloud Volumes ONTAP to explain this and a What's new release note.