### PR TITLE
Supported configurations references added to Packages section

### DIFF
--- a/concept-licensing.adoc
+++ b/concept-licensing.adoc
@@ -73,12 +73,12 @@ endif::azure[]
 ifdef::gcp[]
 * Available in the Google Cloud Marketplace as a pay-as-you-go offering or as an annual contract
 endif::gcp[]
-* Supported with selected VM types: 
+* For supported VM types, refer to the following: 
 ifdef::azure[]
-** For Azure: E4s_v3, E4ds_v4, DS4_v2, DS13_v2, E8s_v3, E8ds_v4, E4ds_v5, and E8ds_v5 
+** link:https://docs.netapp.com/us-en/cloud-volumes-ontap-relnotes/reference-configs-azure.html[Supported configurations in Azure^] 
 endif::azure[]
 ifdef::gcp[]
-** For Google Cloud: n2-standard-4, n2-standard-8
+** link:https://docs.netapp.com/us-en/cloud-volumes-ontap-relnotes/reference-configs-gcp.html[Supported configurations in Google Cloud^]
 endif::gcp[]
 * Add on any of NetApp's cloud data services at extra cost
 

--- a/concept-licensing.adoc
+++ b/concept-licensing.adoc
@@ -45,7 +45,8 @@ NOTE: Storage and network usage are calculated in binary gigabytes (GB), where 1
 
 The following capacity-based packages are available for Cloud Volumes ONTAP.
 
-To find supported VM types with the following capacity-based packages, refer to: 
+For a list of supported VM types for Freemium, Optimized, Essentials, Professional, and Edge Cache packages, refer to: 
+
 ifdef::azure[]
 * link:https://docs.netapp.com/us-en/cloud-volumes-ontap-relnotes/reference-configs-azure.html[Supported configurations in Azure^] 
 endif::azure[]

--- a/concept-licensing.adoc
+++ b/concept-licensing.adoc
@@ -45,7 +45,7 @@ NOTE: Storage and network usage are calculated in binary gigabytes (GB), where 1
 
 The following capacity-based packages are available for Cloud Volumes ONTAP.
 
-For a list of supported VM types for Freemium, Optimized, Essentials, Professional, and Edge Cache packages, refer to: 
+For a list of supported VM types with the following capacity-based packages, refer to: 
 
 ifdef::azure[]
 * link:https://docs.netapp.com/us-en/cloud-volumes-ontap-relnotes/reference-configs-azure.html[Supported configurations in Azure^] 

--- a/concept-licensing.adoc
+++ b/concept-licensing.adoc
@@ -45,6 +45,14 @@ NOTE: Storage and network usage are calculated in binary gigabytes (GB), where 1
 
 The following capacity-based packages are available for Cloud Volumes ONTAP.
 
+To find supported VM types with the following capacity-based packages, refer to: 
+ifdef::azure[]
+* link:https://docs.netapp.com/us-en/cloud-volumes-ontap-relnotes/reference-configs-azure.html[Supported configurations in Azure^] 
+endif::azure[]
+ifdef::gcp[]
+* link:https://docs.netapp.com/us-en/cloud-volumes-ontap-relnotes/reference-configs-gcp.html[Supported configurations in Google Cloud^]
+endif::gcp[]
+
 ==== Freemium
 
 Provides all Cloud Volumes ONTAP features free of charge from NetApp (cloud provider charges still apply).
@@ -72,13 +80,6 @@ ifdef::azure[]
 endif::azure[]
 ifdef::gcp[]
 * Available in the Google Cloud Marketplace as a pay-as-you-go offering or as an annual contract
-endif::gcp[]
-* For supported VM types, refer to the following: 
-ifdef::azure[]
-** link:https://docs.netapp.com/us-en/cloud-volumes-ontap-relnotes/reference-configs-azure.html[Supported configurations in Azure^] 
-endif::azure[]
-ifdef::gcp[]
-** link:https://docs.netapp.com/us-en/cloud-volumes-ontap-relnotes/reference-configs-gcp.html[Supported configurations in Google Cloud^]
 endif::gcp[]
 * Add on any of NetApp's cloud data services at extra cost
 


### PR DESCRIPTION
Supported configurations in Azure and in Google Cloud have been updated in the Release notes repository to provide un updated list of all supported VM instance types for all packages. As a result, I removed the VM instance types from the Optimized package section and added reference links to the Supported configurations pages under the parent heading "Packages".

